### PR TITLE
Add sku and mpn to product schema

### DIFF
--- a/src/Resources/views/_structured_data.html.twig
+++ b/src/Resources/views/_structured_data.html.twig
@@ -38,6 +38,7 @@
   {
     "@context": "http://schema.org",
     "@type": "Product",
+    "sku": "{{ product.code }}",
     {% if reviews is not empty %}
       "aggregateRating": {
         "@type": "AggregateRating",
@@ -74,6 +75,7 @@
       "offerCount": "{{ product.variants | length }}",
       "priceCurrency": "{{ sylius.channel.baseCurrency.code }}"
     },
+    "mpn": "{{ product.code }}",
     "url": "{{ app.request.uri }}"
   }
 </script>


### PR DESCRIPTION
Fixes two search console warnings:
Missing field "sku"
No global identifier provided (e.g., gtin, mpn, isbn)